### PR TITLE
Added redraw() method that forces features to be redrawn after the remov...

### DIFF
--- a/AnimatedCluster.js
+++ b/AnimatedCluster.js
@@ -110,7 +110,15 @@ OpenLayers.Strategy.AnimatedCluster = OpenLayers.Class(OpenLayers.Strategy.Clust
             this.animationTween = null;
         }
     },
-    
+    /**
+     * Redraw features.
+     */
+    redraw: function() {
+        // After removeAllFeatures and/or destroyFeatures is called it removes only clusters
+        // but but they don't affect the original features the clustering strategy holds in cache.
+        // Changing the clustering strategy resolution forces the addFeatures() to redraw features.
+        this.resolution = -1;
+    },
     /**
      * Method: cluster
      * Cluster features based on some threshold distance.


### PR DESCRIPTION
I have come across the following issue with the animated cluster:

When calling removeAllFeatures and/or destroyFeatures on the layer, then calling addFeatures with a new set of features, then zooming in and out again I get the original set of features present on the layer.

This is because removeAllFeatures and/or destroyFeatures removes only clusters but but they don't affect the original features the clustering strategy holds in cache. Changing the clustering strategy resolution forces the addFeatures() to redraw features and solves this issue.